### PR TITLE
Downgrade git-versioning because of CircleCI tag issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java-library"
     id "maven-publish"
-    id "me.qoomon.git-versioning" version "6.4.0"
+    id "me.qoomon.git-versioning" version "6.3.6"
 }
 
 repositories {


### PR DESCRIPTION
For some reason, the CircleCI wasn't changing the version based on the tag in the new version and downgrading seems to work. Will raise an issue on the library side.