### PR TITLE
Update c-kzg-4844 to v0.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,9 @@ jobs:
           shell: bash.exe
           name: "Build and test java binding"
           command: |
-            export JAVA_HOME="/c/ProgramData/chocolatey/lib/openjdk11"
+            ls "/c/ProgramData/chocolatey/lib/openjdk11"
+            ls "/c/Program Files/Eclipse Adoptium/jdk-11.0.19.7-hotspot"
+            export JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-11.0.19.7-hotspot"
             cd c-kzg-4844/bindings/java
             export PRESET=mainnet
             make build -B

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,13 +131,13 @@ jobs:
           command: |
             choco install make
             choco install mingw --yes
+            choco install openjdk11 --yes
       - build_blst
       - run:
           shell: bash.exe
           name: "Build and test java binding"
           command: |
-            ls "/c/Program Files/OpenJDK/"
-            export JAVA_HOME="/c/Program Files/OpenJDK/jdk-17"
+            export JAVA_HOME="/c/Program Files/OpenJDK/jdk-11"
             cd c-kzg-4844/bindings/java
             export PRESET=mainnet
             make build -B

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
           shell: bash.exe
           name: "Build and test java binding"
           command: |
-            export JAVA_HOME="/c/Program Files/OpenJDK/jdk-11"
+            export JAVA_HOME="/c/ProgramData/chocolatey/lib/openjdk11"
             cd c-kzg-4844/bindings/java
             export PRESET=mainnet
             make build -B

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,8 @@ jobs:
           shell: bash.exe
           name: "Build and test java binding"
           command: |
+            ls /c/Program Files/OpenJDK/
+            export JAVA_HOME="/c/Program Files/OpenJDK/jdk-11"
             cd c-kzg-4844/bindings/java
             export PRESET=mainnet
             make build -B

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,6 @@ jobs:
           shell: bash.exe
           name: "Build and test java binding"
           command: |
-            ls "/c/ProgramData/chocolatey/lib/openjdk11"
-            ls "/c/Program Files/Eclipse Adoptium/jdk-11.0.19.7-hotspot"
             export JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-11.0.19.7-hotspot"
             cd c-kzg-4844/bindings/java
             export PRESET=mainnet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,8 +136,8 @@ jobs:
           shell: bash.exe
           name: "Build and test java binding"
           command: |
-            ls /c/Program Files/OpenJDK/
-            export JAVA_HOME="/c/Program Files/OpenJDK/jdk-11"
+            ls "/c/Program Files/OpenJDK/"
+            export JAVA_HOME="/c/Program Files/OpenJDK/jdk-17"
             cd c-kzg-4844/bindings/java
             export PRESET=mainnet
             make build -B


### PR DESCRIPTION
Updates c-kzg-4844 to the new release:

* https://github.com/ethereum/c-kzg-4844/releases/tag/v0.2.0