### PR TITLE
Update c-kzg-4844 to v1.0.0 + other version updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,19 +7,19 @@ orbs:
 executors:
   linux_executor:
     docker:
-      - image: cimg/openjdk:11.0.20
+      - image: cimg/openjdk:11.0.22
     resource_class: medium
     working_directory: ~/jc-kzg-4844
 
   linux_executor_arm64:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: arm.medium
     working_directory: ~/jc-kzg-4844
 
   mac_os_executor:
     macos:
-      xcode: "14.3.1"
+      xcode: "15.3.0"
     working_directory: ~/jc-kzg-4844
 
 commands:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://circleci.com/gh/Consensys/jc-kzg-4844.svg?style=svg)](https://circleci.com/gh/Consensys/workflows/jc-kzg-4844)
 [![GitHub license](https://img.shields.io/github/license/Consensys/jc-kzg-4844.svg?logo=apache)](https://github.com/Consensys/jc-kzg-4844/blob/master/LICENSE)
-[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v0.4.0-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v0.4.0)
+[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v1.0.0-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v1.0.0)
 [![Latest version of 'jc-kzg-4844' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/consensys/maven/maven/jc-kzg-4844/latest/a=noarch;xg=tech.pegasys/?render=true&show_latest=true)](https://cloudsmith.io/~consensys/repos/maven/packages/detail/maven/jc-kzg-4844/latest/a=noarch;xg=tech.pegasys/)
 
 Provides building and packaging of the [Java bindings](https://github.com/ethereum/c-kzg-4844/tree/main/bindings/java) in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java-library"
     id "maven-publish"
-    id "me.qoomon.git-versioning" version "6.4.1"
+    id "me.qoomon.git-versioning" version "6.4.3"
 }
 
 repositories {


### PR DESCRIPTION
Updated to https://github.com/ethereum/c-kzg-4844/releases/tag/v1.0.0

This will allow aligning the version of our library to the version of `c-kzg-4844`. Technically no updates in the Java binding, so everything should be as before.