### PR TITLE
Only sign and deploy (jreleaser)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - run:
           name: "Publish"
           command: |
-            ./gradlew --no-daemon --parallel checkJarContents publish jreleaserFullRelease
+            ./gradlew --no-daemon --parallel checkJarContents publish jreleaserSign jreleaserDeploy
 
 workflows:
   version: 2

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,11 @@ publishing {
 }
 
 jreleaser {
+  release {
+    github {
+      enabled = false
+    }
+  }
   signing {
     active = "ALWAYS"
     armored = true

--- a/build.gradle
+++ b/build.gradle
@@ -83,11 +83,6 @@ publishing {
 }
 
 jreleaser {
-  release {
-    github {
-      enabled = false
-    }
-  }
   signing {
     active = "ALWAYS"
     armored = true


### PR DESCRIPTION
`jreleaserFullRelease` does GitHub release, tagging, etc. We only need to publish to Maven Central.