### PR TITLE
Use jreleaserFullRelease

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - run:
           name: "Publish"
           command: |
-            ./gradlew --no-daemon --parallel --stacktrace checkJarContents publish jreleaserSign jreleaserDeploy
+            ./gradlew --no-daemon --parallel --stacktrace checkJarContents publish jreleaserFullRelease
 
 workflows:
   version: 2


### PR DESCRIPTION
Apparently jreleaserDeploy only uploads to staging, but doesn't upload the bundle to Maven Central