### PR TITLE
Update c-kzg to 2.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://circleci.com/gh/Consensys/jc-kzg-4844.svg?style=svg)](https://circleci.com/gh/Consensys/workflows/jc-kzg-4844)
 [![GitHub license](https://img.shields.io/github/license/Consensys/jc-kzg-4844.svg?logo=apache)](https://github.com/Consensys/jc-kzg-4844/blob/master/LICENSE)
-[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v2.1.4-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.4)
+[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v2.1.5-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.5)
 [![Maven Central](https://img.shields.io/maven-central/v/io.consensys.protocols/jc-kzg-4844)](https://central.sonatype.com/artifact/io.consensys.protocols/jc-kzg-4844)
 
 Provides building and packaging of the [Java bindings](https://github.com/ethereum/c-kzg-4844/tree/main/bindings/java) in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates c-kzg-4844 to v2.1.5, adjusting the README badge and advancing the submodule commit.
> 
> - **Dependencies**:
>   - Update `c-kzg-4844` submodule to commit `7043f4d`.
> - **Docs**:
>   - Bump README badge for `c-kzg-4844` from `v2.1.4` to `v2.1.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f5332c4c4d2c17a229400acd877cfe4fad489a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->