### PR TITLE
Update version badge for c-kzg-4844 to v2.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci](https://github.com/Consensys/jc-kzg-4844/actions/workflows/ci.yml/badge.svg)](https://github.com/Consensys/jc-kzg-4844/actions/workflows/ci.yml)
 [![GitHub license](https://img.shields.io/github/license/Consensys/jc-kzg-4844.svg?logo=apache)](https://github.com/Consensys/jc-kzg-4844/blob/master/LICENSE)
-[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v2.1.5-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.5)
+[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v2.1.6-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.6)
 [![Maven Central](https://img.shields.io/maven-central/v/io.consensys.protocols/jc-kzg-4844)](https://central.sonatype.com/artifact/io.consensys.protocols/jc-kzg-4844)
 
 Provides building and packaging of the [Java bindings](https://github.com/ethereum/c-kzg-4844/tree/main/bindings/java) in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or build logic is modified.
> 
> **Overview**
> Updates `README.md` to bump the `c-kzg-4844` version badge/link from `v2.1.5` to `v2.1.6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a40df3a4f26c37f6612ef5156e8a7e03005bb8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->