### PR TITLE
updated to 2.1.8 of c-kzg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin' 
       - name: Install dependencies
         run: |
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin' 
           architecture: 'arm64'  
       - name: Build blst
@@ -70,7 +70,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin' 
       - name: Build blst (arm64)
         run: |
@@ -101,7 +101,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin' 
       - name: Install build tools
         run: |
@@ -132,7 +132,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin' 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -190,7 +190,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci](https://github.com/Consensys/jc-kzg-4844/actions/workflows/ci.yml/badge.svg)](https://github.com/Consensys/jc-kzg-4844/actions/workflows/ci.yml)
 [![GitHub license](https://img.shields.io/github/license/Consensys/jc-kzg-4844.svg?logo=apache)](https://github.com/Consensys/jc-kzg-4844/blob/master/LICENSE)
-[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v2.1.6-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.6)
+[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v2.1.8-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.8)
 [![Maven Central](https://img.shields.io/maven-central/v/io.consensys.protocols/jc-kzg-4844)](https://central.sonatype.com/artifact/io.consensys.protocols/jc-kzg-4844)
 
 Provides building and packaging of the [Java bindings](https://github.com/ethereum/c-kzg-4844/tree/main/bindings/java) in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ gitVersioning.apply {
 }
 
 java {
-    sourceCompatibility = 17
-    targetCompatibility = 17
+    sourceCompatibility = 25
+    targetCompatibility = 25
     withJavadocJar()
     withSourcesJar()
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Raising bytecode and CI to Java 25 is a breaking compatibility change for downstream apps still on JDK 17/21; pairing with a c-kzg-4844 release also affects native KZG behavior shipped in the JAR.
> 
> **Overview**
> Aligns the project with **c-kzg-4844 v2.1.8** (README badge/link) and moves the whole build to **Java 25**.
> 
> CI now uses `java-version: '25'` on every job (Linux x86/arm, macOS, Windows, assemble, publish), and `build.gradle` sets **source/target compatibility to 25** (was 17). That raises the minimum JDK for building and consuming the published library compared to the previous 17 bytecode target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90385742ad89dcc48e942afc1d4d0407ee1083f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->