### PR TITLE
updated to 2.1.8 of c-kzg attempt 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci](https://github.com/Consensys/jc-kzg-4844/actions/workflows/ci.yml/badge.svg)](https://github.com/Consensys/jc-kzg-4844/actions/workflows/ci.yml)
 [![GitHub license](https://img.shields.io/github/license/Consensys/jc-kzg-4844.svg?logo=apache)](https://github.com/Consensys/jc-kzg-4844/blob/master/LICENSE)
-[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v2.1.6-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.6)
+[![Version of 'c-kzg-4844'](https://img.shields.io/badge/c--kzg--4844-v2.1.8-blue.svg)](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.8)
 [![Maven Central](https://img.shields.io/maven-central/v/io.consensys.protocols/jc-kzg-4844)](https://central.sonatype.com/artifact/io.consensys.protocols/jc-kzg-4844)
 
 Provides building and packaging of the [Java bindings](https://github.com/ethereum/c-kzg-4844/tree/main/bindings/java) in [C-KZG-4844](https://github.com/ethereum/c-kzg-4844).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only badge/link change with no runtime or build logic modified in this diff.
> 
> **Overview**
> Updates the README **c-kzg-4844** version badge and release link from **v2.1.6** to **v2.1.8**, aligning documented upstream dependency with the newer [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844/releases/tag/v2.1.8) release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856b8829d6281efd1f94c8a0691ccc6b14853363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->